### PR TITLE
Add support to specify IP protocols in filter rules.

### DIFF
--- a/apic/apicagent.py
+++ b/apic/apicagent.py
@@ -311,12 +311,12 @@ def addProvidedContracts(spec, apicMoDir):
     for e in epgList:
         epg = SafeDict(e)
         serviceName = epg['name']
-        protocolPorts = epg['protoports']
-        if protocolPorts is 'missing':
+        filters = epg['filterinfo']
+        if filters is 'missing':
             print "No provider in ", serviceName
             continue
 
-        print ">>Provider ", protocolPorts, serviceName
+        print ">>Provider ", filters, serviceName
         epgcR = ConfigRequest()
         # filter container
         filterName = 'filt-' + appName + serviceName
@@ -324,10 +324,10 @@ def addProvidedContracts(spec, apicMoDir):
         # save the filter dn to this app's resource list
         resrcList.append(filterMo) 
     
-	for eachEntry in protocolPorts:
-	    protoPortSet = SafeDict(eachEntry)
-            ipProtocol = protoPortSet['protocol']
-            servPort = protoPortSet['servport']
+	for eachEntry in filters:
+	    filterEntry = SafeDict(eachEntry)
+            ipProtocol = filterEntry['protocol']
+            servPort = filterEntry['servport']
 	   
             etherType = 'ip'
             filterProto = 0
@@ -663,7 +663,7 @@ def validateData(jsData):
             return ['failed', 'epg must have a vlantag']
 
         # build set of provided services
-        if not epg['protoports'] is 'missing':
+        if not epg['filterinfo'] is 'missing':
             provideSet.add(epg['name'])
 
         if epg['uses'] is 'missing':


### PR DESCRIPTION
After this change:
1. From the netmaster, instead of just a list of ports, we'll get a list of (protocol, port) pairs. Supported protocols are ICMP, TCP, UDP.
2. The filter entries will be created like: "entry-<protocol>-<port>:
eg: entry-ip-icmp, entry-ip-udp-4545
3. The filter entries will be created based on what is configured/not.

NOTE: We still support only etherType IP. Need to enhance this to support other etherTypes as required.
