### PR TITLE
Dockerfile: shrink image & update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM ubuntu:15.04
+FROM alpine
+MAINTAINER contiv
 
-# install python pip, wget etc.
-RUN apt-get update
-RUN apt-get -y install python-pip wget
+ARG https_proxy
 
-# install eazyinstall
-ENV https_proxy="https://proxy.esl.cisco.com:8080" 
-RUN pip install Flask
-RUN wget https://bootstrap.pypa.io/ez_setup.py -O - | python
+RUN apk --no-cache add wget python ca-certificates py-pip \
+ && pip install --upgrade pip \
+ && pip install Flask \
+ && mkdir ./cobra \
+ && ln -s /usr/bin/easy_install-2.7 /usr/bin/easy_install
 
-RUN mkdir ./cobra
 WORKDIR ./cobra
 COPY apic .
 
@@ -17,12 +16,13 @@ ARG APIC_URL
 ARG APIC_PKG_VERSION
 
 # unset proxy and download egg files
-RUN unset https_proxy; wget --no-check-certificate https://$APIC_URL/cobra/_downloads/acicobra-$APIC_PKG_VERSION.egg
-RUN unset https_proxy; wget --no-check-certificate https://$APIC_URL/cobra/_downloads/acimodel-$APIC_PKG_VERSION.egg
-
-# install python package form egg files
-RUN easy_install ./acicobra-$APIC_PKG_VERSION.egg
-RUN easy_install ./acimodel-$APIC_PKG_VERSION.egg
-ENV https_proxy="" 
+RUN unset https_proxy \
+ && URL_PREFIX=https://$APIC_URL/cobra/_downloads \
+ && wget --no-check-certificate $URL_PREFIX/acicobra-$APIC_PKG_VERSION.egg \
+ && wget --no-check-certificate $URL_PREFIX/acimodel-$APIC_PKG_VERSION.egg \
+ && easy_install ./acicobra-$APIC_PKG_VERSION.egg \
+ && easy_install ./acimodel-$APIC_PKG_VERSION.egg \
+ && rm ./acicobra-$APIC_PKG_VERSION.egg \
+ && rm ./acimodel-$APIC_PKG_VERSION.egg
 
 CMD /usr/bin/python /cobra/apicagent.py

--- a/README.md
+++ b/README.md
@@ -6,19 +6,23 @@ Receives REST requests from netmaster and performs the corresponding apic config
 
 The SDK needs to be downloaded from an APIC. It is not yet available from a Cisco download site.
 The following information should be provided as arguments to the docker build.
-a) APIC URL.
-b) SDK version.
+a) APIC URL
+b) SDK version
+c) https_proxy if the environment requires a proxy
 
 The SDK version corresponding to the APIC software can be found looking at the files at https://<apic_url>/cobra/_downloads/
 
 The command to build the aci-gw container is:
 ```
-docker build --build-arg APIC_URL=<apic_url> --build-arg APIC_PKG_VERSION=<apic_sdk_version> -t contiv/aci-gw -f Dockerfile .
+docker build --build-arg APIC_URL=<apic_url> --build-arg APIC_PKG_VERSION=<apic_sdk_version> \
+ --force-rm -t contiv/aci-gw .
 ```
 
 Example:
 ```
-docker build --build-arg APIC_URL=172.31.152.18 --build-arg APIC_PKG_VERSION=1.1_1.67-py2.7 -t contiv/aci-gw:09-27-2016.2.0_2g -f Dockerfile .
+docker build --build-arg APIC_URL=172.31.152.18 --build-arg APIC_PKG_VERSION=1.1_1.67-py2.7 \
+ --build-arg https_proxy="https://proxy.esl.cisco.com:8080" --force-rm \
+ -t contiv/aci-gw:09-27-2016.2.0_2g .
 ```
 
 ### Pre-requisites for ACI setup


### PR DESCRIPTION
This PR modifies the Dockerfile to build a smaller image with fewer layers. This Dockerfile is based on a Dockerfile written by Neelima. I've refactored it and tested it.

contiv/aci-gw:11-28-2016.1.3_2i had a size of 765 MB. An image based on this Dockerfile had a size of 390 MB and 10 layers.